### PR TITLE
Feature/build diff

### DIFF
--- a/DeepDiffTests/DeleteTests.swift
+++ b/DeepDiffTests/DeleteTests.swift
@@ -15,7 +15,7 @@ class DeleteTests: XCTestCase {
         let x: [Int] = [0, 1, 2, 3]
         let y: [Int] = [1, 2, 3]
         let (diff, updates) = x.deepDiff(y)
-        XCTAssertEqual([DiffStep.delete(fromIndex: 0)], diff)
+        XCTAssertEqual([DiffStep.delete(fromIndex: 0, item: 0)], diff)
         XCTAssertEqual([], updates)
     }
 
@@ -23,7 +23,7 @@ class DeleteTests: XCTestCase {
         let x: [Int] = [1, 2, 3, 0]
         let y: [Int] = [1, 2, 3]
         let (diff, updates) = x.deepDiff(y)
-        XCTAssertEqual([DiffStep.delete(fromIndex: 3)], diff)
+        XCTAssertEqual([DiffStep.delete(fromIndex: 3, item: 0)], diff)
         XCTAssertEqual([], updates)
     }
 
@@ -31,7 +31,7 @@ class DeleteTests: XCTestCase {
         let x: [Int] = [1, 2, 0, 3]
         let y: [Int] = [1, 2, 3]
         let (diff, updates) = x.deepDiff(y)
-        XCTAssertEqual([DiffStep.delete(fromIndex: 2)], diff)
+        XCTAssertEqual([DiffStep.delete(fromIndex: 2, item: 0)], diff)
         XCTAssertEqual([], updates)
     }
 
@@ -40,9 +40,9 @@ class DeleteTests: XCTestCase {
         let y: [Int] = [1, 2, 3]
         let (diff, updates) = x.deepDiff(y)
         let expectedDiff: [DiffStep<Int,Int>] = [
-            DiffStep.delete(fromIndex: 0),
-            DiffStep.delete(fromIndex: 2),
-            DiffStep.delete(fromIndex: 3),
+            DiffStep.delete(fromIndex: 0, item: 4),
+            DiffStep.delete(fromIndex: 3, item: 5),
+            DiffStep.delete(fromIndex: 5, item: 6),
         ]
         XCTAssertEqual(expectedDiff, diff)
         XCTAssertEqual([], updates)

--- a/DeepDiffTests/MoveTests.swift
+++ b/DeepDiffTests/MoveTests.swift
@@ -31,7 +31,7 @@ class MoveTests: XCTestCase {
         let x: [Int] = [1, 2, 0, 3]
         let y: [Int] = [1, 0, 2, 3]
         let (diff, updates) = x.deepDiff(y)
-        XCTAssertEqual([DiffStep.move(fromIndex: 2, toIndex: 1)], diff)
+        XCTAssertEqual([DiffStep.move(fromIndex: 1, toIndex: 2)], diff)
         XCTAssertEqual([], updates)
     }
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # DeepDiff
+
+##Notes
+The indices of the updates you will get from calling `deepDiff(b: CollectionType)` refer to the end indices after moves/inserts/deletes. This means that you won't want to use `reloadItemsAtIndexPaths` within a batch update of the `CollectionView`


### PR DESCRIPTION
- In DiffStep enum I included the object in .delete. This is so that we can keep track if we are inserting and deleting the same object or different object. You may be able to do this without the object in delete as @ianterrell thought.
- This implementation of `processDiff` doesn't handle a combo of insert/delete on the same object at the same index, it will will just leave those steps as is. I commented on the line where that may be handled (163).
